### PR TITLE
Fixed Dockerfile for GPUs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM tensorflow/tensorflow:2.11.0-gpu
+FROM tensorflow/tensorflow:latest-gpu
 
-LABEL MWA_sgan.version="1.0"
+LABEL MWA_sgan.version="1.1"
 
 # Install prerequisites
 ARG DEBIAN_FRONTEND=noninteractive
@@ -20,7 +20,6 @@ RUN apt-get update -qq && \
     libpng-dev \
     libtool \
     libx11-dev \
-    nvidia-utils-515 \
     pgplot5 \
     python3-dev \
     python3-numpy \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN git clone https://github.com/scottransom/presto.git
 
 # Install presto python scripts
 ENV PRESTO /code/presto
-ENV LD_LIBRARY_PATH /code/presto/lib
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${PRESTO}/lib"
 
 WORKDIR /code/presto/src
 # The following is necessary if your system isn't Ubuntu 20.04


### PR DESCRIPTION
We were already there! It only required us to remove the manual installation of the nvidia uils package inside the container.
Some of the errors on `import tensorflow` were caused by the Dockerfile overriding (instead of appending to) the `LD_LIBRARY_PATH` environment variable.